### PR TITLE
add options.globalPaths for global includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-node-lessify 
+node-lessify
 ============
 Version 0.1.4
 
@@ -55,9 +55,9 @@ LESS allows one to ```@import``` other LESS files. This module synchronously imp
 See the dummy app in the [test directory](/test) for an example of this in action.
 
 ### Append Less file source URL
-As a workaround to LESS source map issues (e.g. css style lines not referring to the correct LESS file), we can output 
- only the source LESS file name for each require() call of a LESS file. This will at least allow us to distinguish 
- STYLE elements. 
+As a workaround to LESS source map issues (e.g. css style lines not referring to the correct LESS file), we can output
+ only the source LESS file name for each require() call of a LESS file. This will at least allow us to distinguish
+ STYLE elements.
 
 ### Plugins
 You can pass a `plugins` argument to get less plugins like [autoprefix](https://www.npmjs.com/package/less-plugin-autoprefix):
@@ -70,11 +70,29 @@ For example (from [test.js](test/test.js)):
 	var b = browserify(sampleLESS);
 	b.transform(lessify, {
 		compileOptions: {
-			plugins: [autoprefix] 
+			plugins: [autoprefix]
 		}
 	});
 
 Note: This does not currently work via `package.json` arguments, since the plugins need to be required separately, but we're working on it.
+
+### Global Paths
+Pass a `globalPaths` option to append search paths to `less.render`.  These paths will be searched for any `@import` calls.
+
+	var b = browserify(sampleLESS);
+	b.transform(lessify, {
+		globalPaths: {
+			paths: [`${__dirname}/myproject/src/globals`],
+		}
+	});
+
+So we can now just do simple includes in any of our less files
+
+`src/my/really/long/path/file.less`:
+
+	@import colors.less; // Will look for myproject/src/globals/colors.less
+
+
 
 ## Changes
 **v0.1.3, v0.1.4**: Added badges

--- a/index.js
+++ b/index.js
@@ -64,8 +64,14 @@ module.exports = function (file, transformOptions) {
 		myDirName = path.dirname(file);
 
 	var compileOptions = assign({}, curTransformOptions.compileOptions || {}, {
-		paths: [".", myDirName] // override the "paths" property
+		paths: [".", myDirName], // override the "paths" property
 	});
+
+	if (transformOptions.globalPaths) {
+		transformOptions.globalPaths.forEach(function(path) {
+			compileOptions.paths.push(path);
+		});
+	}
 
 	return through(write, end);
 


### PR DESCRIPTION
node-lessify kinda wack the way it overrides paths.  This allows us to specify some global paths to include when searching for includes.

Now we can do something like:

```
b.transform(lessify, {
	globalPaths: `${__dirname}/../src/globals`,
});
```

and just

```
@import variables.less;
```

from within less files.

@mbernardy @chevett 